### PR TITLE
Update lein command in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: lein
 
 script:
   - ./scripts/build


### PR DESCRIPTION
Looks like `lein2` is no longer valid on travis ci. My fork build [passes](https://travis-ci.org/evanjbowling/decimal).

Let me know if you want to me copy [this statement](https://github.com/funcool/decimal/blob/master/CONTRIBUTING.md) in this PR. I'm happy to do so if necessary. I'm also curious where you got that phrasing from.